### PR TITLE
Foolin around with geocoder config

### DIFF
--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,0 +1,4 @@
+Geocoder.configure(
+  lookup: :nominatim,
+  http_headers: { "User-Agent" => "Tom Lovett" },
+)


### PR DESCRIPTION
Told you it was simple!

Various config options: https://github.com/alexreisner/geocoder/blob/master/lib/geocoder/configuration.rb
Different APIs, with good info on pricing, rate limits, etc: https://github.com/alexreisner/geocoder/blob/master/README_API_GUIDE.md

Current config is default functionality. When testing in console, it appeared to be working 🚀 

This was generated using `rails generate geocoder:config`
